### PR TITLE
HSDO-113 Added link formatter for font awesome icon field type

### DIFF
--- a/css/stanford_field_formatters.admin.css
+++ b/css/stanford_field_formatters.admin.css
@@ -1,0 +1,10 @@
+/* line 2, ../scss/stanford_field_formatters.admin.scss */
+option.fa,
+.chosen-container .fa {
+  display: block;
+}
+/* line 6, ../scss/stanford_field_formatters.admin.scss */
+option.fa:before,
+.chosen-container .fa:before {
+  padding-right: 10px;
+}

--- a/js/stanford_field_formatters.js
+++ b/js/stanford_field_formatters.js
@@ -9,6 +9,7 @@
       $('.stanford-fontawesome-icon', context).find('option').each(function () {
         $(this).addClass('fa').addClass('fa-' + $(this).attr('value'));
       });
+      $('.stanford-fontawesome-icon').trigger("chosen:updated");
     }
   }
 })(jQuery);

--- a/js/stanford_field_formatters.js
+++ b/js/stanford_field_formatters.js
@@ -7,12 +7,7 @@
   Drupal.behaviors.stanford_field_formatters = {
     attach: function (context, settings) {
       $('.stanford-fontawesome-icon', context).find('option').each(function () {
-        if (!$(this).hasClass('icon-added')) {
-          var icon = $('<i>', {
-            class: 'fa fa-' + $(this).attr('value')
-          });
-          $(this).addClass('icon-added').prepend(icon);
-        }
+        $(this).addClass('fa').addClass('fa-' + $(this).attr('value'));
       });
     }
   }

--- a/scss/stanford_field_formatters.admin.scss
+++ b/scss/stanford_field_formatters.admin.scss
@@ -1,0 +1,9 @@
+
+option.fa,
+.chosen-container .fa {
+  display: block;
+
+  &:before {
+    padding-right: 10px;
+  }
+}

--- a/stanford_field_formatters.module
+++ b/stanford_field_formatters.module
@@ -45,8 +45,15 @@ function stanford_field_formatters_field_formatter_info() {
       'description' => t('Wrap this field with a link from another field.'),
     ),
     'fontawesome_icon_formatter' => array(
-      'label' => t('Font Awesome Icons'),
+      'label' => t('Icons'),
       'field types' => array('fontawesome_icon'),
+    ),
+    'fontawesome_icon_link' => array(
+      'label' => t('Linked Icons'),
+      'field types' => array('fontawesome_icon'),
+      'settings' => array(
+        'link_field' => '',
+      ),
     ),
   );
   return $formatters;
@@ -94,7 +101,7 @@ function stanford_field_formatters_field_formatter_settings_form($field, $instan
  * Implements hook_field_formatter_settings_summary().
  */
 function stanford_field_formatters_field_formatter_settings_summary($field, $instance, $view_mode) {
-  if ($field['type'] == 'fontawesome_icon') {
+  if ($instance['display'][$view_mode]['type'] == 'fontawesome_icon_formatter') {
     return;
   }
 
@@ -127,9 +134,8 @@ function stanford_field_formatters_field_formatter_settings_summary($field, $ins
  */
 function stanford_field_formatters_field_formatter_view($entity_type, $entity, $field, $instance, $langcode, $items, $display) {
   $element = array();
-  $field_info = field_info_field($field['field_name']);
 
-  switch ($field_info['type']) {
+  switch ($field['type']) {
     case "image":
       $display['settings']['image_link'] = "file";
       $element = image_field_formatter_view($entity_type, $entity, $field, $instance, $langcode, $items, $display);
@@ -143,29 +149,7 @@ function stanford_field_formatters_field_formatter_view($entity_type, $entity, $
       break;
 
     case "fontawesome_icon":
-
-      foreach ($items as $delta => $item) {
-        if (isset($item['icon'])) {
-
-          // Builds font awesome tag <i class="fa fa-{value}"
-          // aria-hidden="true"/>.
-          $element[$delta] = array(
-            '#theme' => 'html_tag',
-            '#tag' => 'i',
-            '#value' => '',
-            '#attributes' => array(
-              'class' => array('fa', 'fa-' . $item['icon']),
-              'aria-hidden' => array("true"),
-            ),
-            '#attached' => array(
-              'css' => array(
-                drupal_get_path('module', 'stanford_field_formatters') . '/css/fontawesome/stanford_fa.css',
-                drupal_get_path('module', 'stanford_field_formatters') . '/css/stanford_field_formatters.css',
-              ),
-            ),
-          );
-        }
-      }
+      $element = stanford_field_formatters_font_awesome_view($entity_type, $entity, $field, $instance, $langcode, $items, $display);
       break;
   }
 
@@ -194,14 +178,60 @@ function _stanford_field_formatters_field_formatter_view_paths(array &$element, 
   }
 
   foreach (array_keys($element) as $index) {
-    if (!empty($paths[$index]) && isset($element[$index]["#path"])) {
-      $element[$index]['#path']['path'] = url($paths[$index]['url']);
-      $element[$index]['#path']['options'] = array();
-    }
-    if (!empty($paths[$index]) && isset($element[$index]["#markup"])) {
-      $element[$index]["#markup"] = l($element[$index]["#markup"], url($paths[$index]['url']), array('html' => TRUE));
+    if (!empty($paths[$index])) {
+
+      if (isset($element[$index]["#path"])) {
+        $element[$index]['#path']['path'] = url($paths[$index]['url']);
+        $element[$index]['#path']['options'] = array();
+      }
+
+      if (isset($element[$index]["#markup"])) {
+
+        $attributes = $paths[$index]['attributes'];
+        $attributes['title'] = $paths[$index]['title'];
+        $link_options = array(
+          'html' => TRUE,
+          'attributes' => $attributes,
+        );
+
+        $element[$index]["#markup"] = l($element[$index]["#markup"], url($paths[$index]['url']), $link_options);
+      }
     }
   }
+}
+
+/**
+ * Build the render array for the font awesome icon field display.
+ */
+function stanford_field_formatters_font_awesome_view($entity_type, $entity, $field, $instance, $langcode, $items, $display) {
+  $element = array();
+  foreach ($items as $delta => $item) {
+    if (isset($item['icon'])) {
+      $tag = array(
+        'element' => array(
+          '#tag' => 'i',
+          '#value' => '',
+          '#attributes' => array(
+            'class' => array('fa', 'fa-' . $item['icon']),
+            'aria-hidden' => array("true"),
+          ),
+        ),
+      );
+
+      // Builds font awesome tag <i class="fa fa-{value}"
+      // aria-hidden="true"/>.
+      $element[$delta] = array(
+        '#markup' => theme('html_tag', $tag),
+        '#attached' => array(
+          'css' => array(
+            drupal_get_path('module', 'stanford_field_formatters') . '/css/fontawesome/stanford_fa.css',
+            drupal_get_path('module', 'stanford_field_formatters') . '/css/stanford_field_formatters.css',
+          ),
+        ),
+      );
+    }
+  }
+  return $element;
 }
 
 /**

--- a/stanford_field_formatters.module
+++ b/stanford_field_formatters.module
@@ -556,16 +556,18 @@ function stanford_field_formatters_field_widget_info() {
  * Implements hook_field_widget_form().
  */
 function stanford_field_formatters_field_widget_form(&$form, &$form_state, $field, $instance, $langcode, $items, $delta, $element) {
+  $path = drupal_get_path('module', 'stanford_field_formatters');
   $icon = array(
     '#type' => 'select',
     '#options' => stanford_field_formatters_get_icons(),
     '#attributes' => array('class' => array('stanford-fontawesome-icon')),
     '#attached' => array(
       'css' => array(
-        drupal_get_path('module', 'stanford_field_formatters') . '/css/fontawesome/stanford_fa.css',
+        "$path/css/fontawesome/stanford_fa.css",
+        "$path/css/stanford_field_formatters.admin.css",
       ),
       'js' => array(
-        drupal_get_path('module', 'stanford_field_formatters') . '/js/stanford_field_formatters.js',
+        "$path/js/stanford_field_formatters.js",
       ),
     ),
     '#default_value' => $items[$delta]['icon'],

--- a/stanford_field_formatters.module
+++ b/stanford_field_formatters.module
@@ -180,20 +180,19 @@ function _stanford_field_formatters_field_formatter_view_paths(array &$element, 
   foreach (array_keys($element) as $index) {
     if (!empty($paths[$index])) {
 
+      $attributes = $paths[$index]['attributes'];
+      $attributes['title'] = $paths[$index]['title'];
+
       if (isset($element[$index]["#path"])) {
         $element[$index]['#path']['path'] = url($paths[$index]['url']);
-        $element[$index]['#path']['options'] = array();
+        $element[$index]['#path']['options'] = $attributes;
       }
 
       if (isset($element[$index]["#markup"])) {
-
-        $attributes = $paths[$index]['attributes'];
-        $attributes['title'] = $paths[$index]['title'];
         $link_options = array(
           'html' => TRUE,
           'attributes' => $attributes,
         );
-
         $element[$index]["#markup"] = l($element[$index]["#markup"], url($paths[$index]['url']), $link_options);
       }
     }
@@ -207,21 +206,14 @@ function stanford_field_formatters_font_awesome_view($entity_type, $entity, $fie
   $element = array();
   foreach ($items as $delta => $item) {
     if (isset($item['icon'])) {
-      $tag = array(
-        'element' => array(
-          '#tag' => 'i',
-          '#value' => '',
-          '#attributes' => array(
-            'class' => array('fa', 'fa-' . $item['icon']),
-            'aria-hidden' => array("true"),
-          ),
-        ),
-      );
-
       // Builds font awesome tag <i class="fa fa-{value}"
       // aria-hidden="true"/>.
       $element[$delta] = array(
-        '#markup' => theme('html_tag', $tag),
+        '#theme' => 'font_awesome_icon',
+        '#path' => array(),
+        '#tag' => 'i',
+        '#value' => '',
+        '#attributes' => array('class' => array('fa', 'fa-' . $item['icon'])),
         '#attached' => array(
           'css' => array(
             drupal_get_path('module', 'stanford_field_formatters') . '/css/fontawesome/stanford_fa.css',
@@ -232,6 +224,39 @@ function stanford_field_formatters_font_awesome_view($entity_type, $entity, $fie
     }
   }
   return $element;
+}
+
+/**
+ * Implements hook_theme().
+ */
+function stanford_field_formatters_theme($existing, $type, $theme, $path) {
+  return array(
+    'font_awesome_icon' => array(
+      'render element' => 'element',
+    ),
+  );
+}
+
+/**
+ * Theme font awesome icons.
+ *
+ * @param array $variables
+ *   Theme variables similar to theme_html_tag().
+ *
+ * @return string
+ *   Render output.
+ */
+function theme_font_awesome_icon(array $variables) {
+  $output = theme('html_tag', $variables);
+
+  if (!empty($variables['element']['#path'])) {
+    $link = array(
+      'html' => TRUE,
+      'attributes' => $variables['element']['#path']['options'],
+    );
+    $output = l($output, $variables['element']['#path']['path'], $link);
+  }
+  return $output;
 }
 
 /**

--- a/stanford_field_formatters.module
+++ b/stanford_field_formatters.module
@@ -247,14 +247,19 @@ function stanford_field_formatters_theme($existing, $type, $theme, $path) {
  *   Render output.
  */
 function theme_font_awesome_icon(array $variables) {
-  $output = theme('html_tag', $variables);
-
   if (!empty($variables['element']['#path'])) {
     $link = array(
       'html' => TRUE,
       'attributes' => $variables['element']['#path']['options'],
     );
-    $output = l($output, $variables['element']['#path']['path'], $link);
+    if (isset($link['attributes']['title'])) {
+      $variables['element']['#value'] = '<span class="visually-hidden">' . $link['attributes']['title'] . '</span>';
+    }
+    $tag = theme('html_tag', $variables);
+    $output = l($tag, $variables['element']['#path']['path'], $link);
+  }
+  else {
+    $output = theme('html_tag', $variables);
   }
   return $output;
 }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Added a link formatter for font awesome icons.

# Needed By (Date)
- 4/12

# Steps to Test

1. Checkout branch
2. Add font awesome icon & link field type to an entity.
3. in the display configuration, set the font awesome icon to display as "Link Icon" and set the settings to use the link field you added
4. create the content/entity and populate the fields
5. validate the font awesome icon displays and is linked to the link field data.
