### PR TITLE
SOE-1896: changed the default to none

### DIFF
--- a/stanford_field_formatters.module
+++ b/stanford_field_formatters.module
@@ -643,7 +643,7 @@ function _stanford_field_formatters_fontawesome_icon_widget_form(&$form, &$form_
         "$path/js/stanford_field_formatters.js",
       ),
     ),
-    '#default_value' => $items[$delta]['icon'],
+    '#defaut_value' => t('- None -'),
   );
   stanford_field_formatters_load_fontawesome();
   return array('icon' => $element + $icon);


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- This sets the default value to "- None -"

# Needed By (Date)
- Would like it for the SoE Magazine

# Urgency
- David has been asking for it.

# Steps to Test

1. Pull this branch 
2. Create a call-to-action block
3. Verify the default value for the font awesome select list is "- None -"

# Affected Projects or Products
- SoE Phase 2, redesign

# Associated Issues and/or People
- Jira tickets:
https://stanfordits.atlassian.net/browse/SOE-1896
- Other PRs:
https://github.com/SU-SWS/stanford_bean_types/pull/60
- Anyone who should be notified? @boznik 


# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)